### PR TITLE
Replace telethon with python-telegram-bot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-telethon
-motor
-openai
+python-telegram-bot==20.7
+motor==3.7.1
+openai==1.106.1


### PR DESCRIPTION
## Summary
- replace telethon dependency with python-telegram-bot
- pin motor and openai versions for compatibility

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9530ae30832195fd267061628410